### PR TITLE
Fixed close_db function param and runtime linking

### DIFF
--- a/etovucca/Makefile
+++ b/etovucca/Makefile
@@ -1,5 +1,6 @@
 CC=gcc
 CFLAGS=-g -Wall -Werror -pedantic -std=gnu99 -I./lib
+LDFLAGS=-L. -Wl,-rpath,.
 TARGET=etovucca
 SRCDIR=src
 LIBDIR=lib
@@ -13,7 +14,7 @@ cgi: etovucca
 		python3 -m http.server --cgi
 
 etovucca: $(DEPS) $(SRCDIR)/RTBB.c
-		$(CC) $(CFLAGS) -o $@ $^ -L./ -lsqlite3
+		$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ -lsqlite3
 
 Database.o: $(SRCDIR)/Database.c
 		$(CC) $(CFLAGS) -o $@ -c $^

--- a/etovucca/src/RTBB.c
+++ b/etovucca/src/RTBB.c
@@ -51,7 +51,7 @@ bool parseDate(const char * const date_in, Date *date_out) {
    return true;
 }
 
-void close_db() {
+void closeDb(void) {
    sqlite3_close(db);
 }
 
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
       printf("Error opening database\n");
       return ERROR;
    }
-   if (atexit(close_db)) {
+   if (atexit(closeDb)) {
       printf("Error registering callback\n");
       return ERROR;
    }


### PR DESCRIPTION
I updated the close_db function name to reflect other function casing and added a parameter declaration to avoid GCC compilation errors.

I also embedded the path to the built sqlite3 shared object for the dynamic linker. 